### PR TITLE
Add tests for LLM parsing and audio edit endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,3 +367,23 @@ WaveQ-Api-Server/
 ---
 
 **WaveQ Audio API Manager** - מערכת מתקדמת לעיבוד אודיו עם תמיכה מלאה ב-n8n ו-MCP 🎵✨
+
+## 🧪 הפעלת בדיקות
+
+להרצת כל הבדיקות השתמשו ב־pytest:
+
+```bash
+pytest
+```
+
+## 📑 דוגמאות לבקשות HTTP
+
+### שליחת בקשה לעריכת אודיו
+
+```bash
+curl -X POST http://localhost:8002/api/audio/edit \
+  -F "audio_file=@/path/to/file.wav" \
+  -F "operation=trim" \
+  -F "parameters={\"start\": 0, \"end\": 5}" \
+  -F "client_id=tester"
+```

--- a/llm.py
+++ b/llm.py
@@ -1,0 +1,33 @@
+import json
+from typing import Any, Dict
+
+
+def parse_request(request_str: str) -> Dict[str, Any]:
+    """Parse an LLM request represented as JSON.
+
+    The request must contain an ``operation`` field and may include a
+    ``parameters`` object.  ``parameters`` must be a dictionary if provided.
+
+    Args:
+        request_str: JSON string describing the audio editing request.
+
+    Returns:
+        Parsed request as a dictionary with ``operation`` and ``parameters``.
+
+    Raises:
+        ValueError: If the JSON is invalid, ``operation`` is missing or
+            ``parameters`` is not a dictionary.
+    """
+    try:
+        data = json.loads(request_str)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid JSON") from exc
+
+    if "operation" not in data:
+        raise ValueError("Missing 'operation'")
+
+    params = data.get("parameters", {})
+    if not isinstance(params, dict):
+        raise ValueError("'parameters' must be an object")
+
+    return {"operation": data["operation"], "parameters": params}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,44 @@
+import io
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api_gateway
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    # Redirect file storage to temporary directory
+    monkeypatch.setattr(api_gateway, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(api_gateway, "PROCESSED_DIR", tmp_path)
+    # Mock MQTT interactions
+    monkeypatch.setattr(api_gateway.mcp_client, "connect", AsyncMock())
+    monkeypatch.setattr(api_gateway.mcp_client, "publish_request", AsyncMock(return_value=True))
+
+    with TestClient(api_gateway.app) as c:
+        yield c
+
+
+def test_audio_edit_success(client):
+    files = {"audio_file": ("test.wav", io.BytesIO(b"fake-audio"), "audio/wav")}
+    data = {"operation": "trim", "parameters": "{}", "client_id": "tester"}
+    response = client.post("/api/audio/edit", files=files, data=data)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "submitted"
+    assert "request_id" in body
+
+
+def test_audio_edit_invalid_operation(client):
+    files = {"audio_file": ("test.wav", io.BytesIO(b"fake-audio"), "audio/wav")}
+    data = {"operation": "invalid", "parameters": "{}"}
+    response = client.post("/api/audio/edit", files=files, data=data)
+    assert response.status_code == 400
+
+
+def test_audio_edit_bad_json(client):
+    files = {"audio_file": ("test.wav", io.BytesIO(b"fake-audio"), "audio/wav")}
+    data = {"operation": "trim", "parameters": "{bad json}"}
+    response = client.post("/api/audio/edit", files=files, data=data)
+    assert response.status_code == 400

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,19 @@
+import pytest
+from llm import parse_request
+
+
+def test_parse_request_valid():
+    req = '{"operation": "trim", "parameters": {"start": 0, "end": 5}}'
+    result = parse_request(req)
+    assert result["operation"] == "trim"
+    assert result["parameters"] == {"start": 0, "end": 5}
+
+
+def test_parse_request_invalid_json():
+    with pytest.raises(ValueError):
+        parse_request('{invalid json}')
+
+
+def test_parse_request_missing_operation():
+    with pytest.raises(ValueError):
+        parse_request('{"parameters": {}}')


### PR DESCRIPTION
## Summary
- add `parse_request` helper and unit tests for LLM request parsing
- add integration tests for `/api/audio/edit`
- document test execution and HTTP usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx -q` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68a463d8d1b8832cb347b488da92eafe