### PR TITLE
Add chat upload page and request status endpoints

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WaveQ - צ'אט</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 flex items-center justify-center min-h-screen">
+    <form action="/chat" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded-lg shadow-md space-y-4">
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">קובץ אודיו</label>
+            <input type="file" name="file" class="w-full text-sm" required>
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">הודעה</label>
+            <input type="text" name="message" class="w-full px-3 py-2 border border-gray-300 rounded" required>
+        </div>
+        <button type="submit" class="w-full bg-purple-600 text-white py-2 rounded hover:bg-purple-700">שלח</button>
+    </form>
+</body>
+</html>

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -150,11 +150,11 @@
                                                         class="text-blue-600 hover:text-blue-900" title="התחל עיבוד">
                                                     <i class="fas fa-play"></i>
                                                 </button>
-                                                <button x-show="request.status === 'completed'" 
-                                                        @click="downloadResult(request.request_id)"
-                                                        class="text-green-600 hover:text-green-900" title="הורד תוצאה">
+                                                <a x-show="request.status === 'completed'"
+                                                   :href="'/api/requests/' + request.request_id + '/download'"
+                                                   class="text-green-600 hover:text-green-900" title="הורד תוצאה">
                                                     <i class="fas fa-download"></i>
-                                                </button>
+                                                </a>
                                                 <button @click="viewRequestDetails(request)"
                                                         class="text-purple-600 hover:text-purple-900" title="פרטי בקשה">
                                                     <i class="fas fa-eye"></i>
@@ -387,14 +387,6 @@
                     } catch (error) {
                         console.error('Error processing request:', error);
                         alert('שגיאה בעיבוד הבקשה');
-                    }
-                },
-                
-                downloadResult(requestId) {
-                    const request = this.requests.find(r => r.request_id === requestId);
-                    if (request && request.result_file) {
-                        alert(`הורדת קובץ: ${request.result_file}`);
-                        // In real app, implement actual download
                     }
                 },
                 


### PR DESCRIPTION
## Summary
- add chat.html template with file upload and message fields
- expose /chat page and API endpoints for request status and downloading processed files
- show download links for processed requests in the requests table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a463d6cdd0832cb02a892ba7705b92