### PR TITLE
feat: add MQTT topics for audio editing

### DIFF
--- a/mcp_audio_server.py
+++ b/mcp_audio_server.py
@@ -75,8 +75,8 @@ class AudioProcessingMCP:
                 port=self.mqtt_port,
                 identifier=self.client_id
             ) as client:
-                await client.subscribe("audio/requests/#")
-                await client.subscribe("audio/status/#")
+                # Listen for edit requests
+                await client.subscribe("audio/edit")
                 
                 self.logger.info("Connected to MQTT broker and subscribed to topics")
                 
@@ -105,7 +105,7 @@ class AudioProcessingMCP:
                         "payload": payload
                     })
                     
-                    if topic.startswith("audio/requests/"):
+                    if topic == "audio/edit":
                         await self.processing_queue.put({
                             "topic": topic,
                             "payload": payload,


### PR DESCRIPTION
## Summary
- publish audio edit requests to shared `audio/edit` MQTT topic
- process edit requests and return statuses via `audio/status/{request_id}`
- listen for status updates in API gateway and track request progress

## Testing
- `python -m py_compile api_gateway.py mcp_audio_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a463cd4764832ca62989c2404e0fa4