### PR TITLE
Integrate LLM parsing into API Gateway

### DIFF
--- a/api_gateway.py
+++ b/api_gateway.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime
 import shutil
 from pathlib import Path
+from llm_service import parse_request as llm_parse_request
 try:
     import redis.asyncio as redis
 except ImportError:  # pragma: no cover - redis is optional
@@ -86,8 +87,31 @@ class ChatRequest(BaseModel):
 
 
 async def parse_request(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Placeholder parser for LLM chat requests"""
-    return {"parsed": True, "input": payload}
+    """Parse chat request payload using the LLM service.
+
+    Extracts the latest message content and forwards it to the LLM parser.
+    Returns the parsed command dictionary on success.
+    Raises HTTPException on errors or malformed responses.
+    """
+
+    messages = payload.get("messages", [])
+    if not messages:
+        raise HTTPException(status_code=400, detail="No messages provided")
+
+    text = messages[-1].get("content")
+    if not text:
+        raise HTTPException(status_code=400, detail="No message content")
+
+    try:
+        result = await asyncio.to_thread(llm_parse_request, text)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"LLM service unavailable: {exc}") from exc
+
+    if not isinstance(result, dict) or not result.get("success") or "data" not in result:
+        error_msg = result.get("error") if isinstance(result, dict) else "Unknown error"
+        raise HTTPException(status_code=502, detail=f"Invalid response from LLM: {error_msg}")
+
+    return result["data"]
 
 # MQTT Client for MCP communication
 class MCPClient:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,3 +42,34 @@ def test_audio_edit_bad_json(client):
     data = {"operation": "trim", "parameters": "{bad json}"}
     response = client.post("/api/audio/edit", files=files, data=data)
     assert response.status_code == 400
+
+
+def test_llm_chat_success(client, monkeypatch):
+    def fake_parse(text):
+        return {"success": True, "data": {"operation": "trim", "parameters": {}}}
+
+    monkeypatch.setattr(api_gateway, "llm_parse_request", fake_parse)
+    payload = {"messages": [{"role": "user", "content": "trim the audio"}]}
+    response = client.post("/api/llm/chat", json=payload)
+    assert response.status_code == 200
+    assert response.json()["response"] == {"operation": "trim", "parameters": {}}
+
+
+def test_llm_chat_malformed_response(client, monkeypatch):
+    def fake_parse(text):
+        return {"success": False, "error": "bad"}
+
+    monkeypatch.setattr(api_gateway, "llm_parse_request", fake_parse)
+    payload = {"messages": [{"role": "user", "content": "trim"}]}
+    response = client.post("/api/llm/chat", json=payload)
+    assert response.status_code == 502
+
+
+def test_llm_chat_unavailable(client, monkeypatch):
+    def fake_parse(text):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(api_gateway, "llm_parse_request", fake_parse)
+    payload = {"messages": [{"role": "user", "content": "trim"}]}
+    response = client.post("/api/llm/chat", json=payload)
+    assert response.status_code == 503


### PR DESCRIPTION
## Summary
- delegate chat request parsing to `llm_service.parse_request`
- handle invalid or unavailable LLM responses
- test LLM chat pathway and error scenarios

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ca0132fc832ca5e7b4cc82305b86