### PR TITLE
Ensure tests import pytest and adjust API tests for JSON

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,7 +1,6 @@
 import pytest
 from llm import parse_request
 
-
 def test_parse_request_valid():
     req = '{"operation": "trim", "parameters": {"start": 0, "end": 5}}'
     result = parse_request(req)


### PR DESCRIPTION
## Summary
- Reorder and expand imports in API tests, adding stub for missing `asyncio_mqtt`
- Ensure LLM tests include explicit pytest import
- Update API tests to send JSON payloads and validate error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5d8e252f4832c8e9bd83a1cc788ef