### PR TITLE
Add voice activity detection using WebRTC VAD

### DIFF
--- a/api_gateway.py
+++ b/api_gateway.py
@@ -586,6 +586,13 @@ async def get_supported_operations():
                 "release": {"type": "float", "description": "Release time in seconds", "default": 0.1}
             }
         },
+        "voice_activity_detection": {
+            "description": "Detect speech segments or remove silence",
+            "parameters": {
+                "remove_silence": {"type": "boolean", "description": "Remove silent sections", "default": False},
+                "aggressiveness": {"type": "integer", "description": "VAD aggressiveness (0-3)", "default": 2},
+            }
+        },
         "merge": {
             "description": "Merge multiple audio files",
             "parameters": {

--- a/audio_agent_library.py
+++ b/audio_agent_library.py
@@ -159,6 +159,24 @@ class AudioAgent:
                     "export as WAV",
                     "save as high quality FLAC"
                 ]
+            },
+            "voice_activity_detection": {
+                "aliases": [
+                    "detect voice",
+                    "voice activity",
+                    "remove silence",
+                    "trim silence",
+                    "cut silence",
+                    "silent parts",
+                    "detect speech"
+                ],
+                "description": "Detect where speech occurs or remove silent sections",
+                "parameters": ["remove_silence"],
+                "examples": [
+                    "detect where there is speech",
+                    "remove silent parts",
+                    "auto trim quiet sections"
+                ]
             }
         }
         
@@ -287,7 +305,16 @@ class AudioAgent:
                 parameters["duration"] = float(time_match.group(1))
             else:
                 parameters["duration"] = 1.0  # Default 1 second
-        
+
+        elif operation == "voice_activity_detection":
+            remove_phrases = [
+                "remove silence",
+                "trim silence",
+                "cut silence",
+                "silent parts",
+            ]
+            parameters["remove_silence"] = any(p in text for p in remove_phrases)
+
         elif operation == "convert_format":
             # Extract format and quality
             format_match = re.search(self.patterns["format"], text)
@@ -317,6 +344,7 @@ class AudioAgent:
         # Sort operations by priority and dependencies
         operation_order = [
             "noise_reduction",  # Do noise reduction first
+            "voice_activity_detection",
             "normalize",        # Then normalize
             "equalize",         # Then equalize
             "compress",         # Then compress

--- a/mcp_audio_server.py
+++ b/mcp_audio_server.py
@@ -17,6 +17,7 @@ import uuid
 from pydub import AudioSegment, effects
 import soundfile as sf
 import librosa
+import webrtcvad
 
 # Import our Audio Agent
 from audio_agent_library import AudioAgent
@@ -188,6 +189,53 @@ class AudioProcessingMCP:
         processed.export(out_path, format="wav")
         return {"output_path": str(out_path)}
 
+    async def voice_activity_detection(self, file_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Detect voice activity or remove silent segments using WebRTC VAD"""
+        aggressiveness = int(params.get("aggressiveness", 2))
+        remove_silence = params.get("remove_silence", False)
+
+        audio = (
+            AudioSegment.from_file(file_path)
+            .set_frame_rate(16000)
+            .set_channels(1)
+            .set_sample_width(2)
+        )
+        raw = audio.raw_data
+        sample_rate = audio.frame_rate
+        frame_ms = 30
+        frame_bytes = int(sample_rate * frame_ms / 1000) * audio.sample_width
+
+        vad = webrtcvad.Vad(aggressiveness)
+        segments: List[Dict[str, float]] = []
+        start: Optional[float] = None
+
+        for i in range(0, len(raw), frame_bytes):
+            frame = raw[i : i + frame_bytes]
+            if len(frame) < frame_bytes:
+                break
+            is_speech = vad.is_speech(frame, sample_rate)
+            t = (i // frame_bytes) * (frame_ms / 1000.0)
+            if is_speech and start is None:
+                start = t
+            elif not is_speech and start is not None:
+                segments.append({"start": start, "end": t})
+                start = None
+
+        if start is not None:
+            segments.append({"start": start, "end": len(audio) / 1000.0})
+
+        result: Dict[str, Any] = {"voice_segments": segments}
+
+        if remove_silence and segments:
+            combined = AudioSegment.empty()
+            for seg in segments:
+                combined += audio[int(seg["start"] * 1000) : int(seg["end"] * 1000)]
+            out_path = self.processed_dir / f"vad_{Path(file_path).stem}.wav"
+            combined.export(out_path, format="wav")
+            result["output_path"] = str(out_path)
+
+        return result
+
     async def merge_audio_files(self, file_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
         files = [file_path] + params.get("additional_files", [])
         segments = [AudioSegment.from_file(p) for p in files]
@@ -229,6 +277,7 @@ class AudioProcessingMCP:
             "noise_reduction": self.noise_reduction,
             "equalize": self.equalize_audio,
             "compress": self.compress_audio,
+            "voice_activity_detection": self.voice_activity_detection,
         }
         for op in operations:
             name = op.get("name")
@@ -265,6 +314,7 @@ class AudioProcessingMCP:
             "noise_reduction": self.noise_reduction,
             "equalize": self.equalize_audio,
             "compress": self.compress_audio,
+            "voice_activity_detection": self.voice_activity_detection,
             "merge": self.merge_audio_files,
             "split": self.split_audio,
             "convert": self.convert_format,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ librosa>=0.10.1
 soundfile>=0.12.1
 numpy>=1.26.0
 scipy>=1.11.0
+webrtcvad>=2.0.10
 
 # MQTT communication
 paho-mqtt>=1.6.1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -41,6 +41,7 @@ def sample_wav(tmp_path):
         ("noise_reduction", {"strength": 0.1}),
         ("equalize_audio", {"low_gain": 1.0, "mid_gain": 1.0, "high_gain": 1.0}),
         ("compress_audio", {"threshold": -20}),
+        ("voice_activity_detection", {"remove_silence": True}),
     ],
 )
 def test_audio_operations(sample_wav, operation, params):


### PR DESCRIPTION
## Summary
- add `webrtcvad` dependency and expose voice activity detection operation
- implement `voice_activity_detection` for trimming silent segments or reporting speech ranges
- wire new operation into operation maps, API metadata, and supported operations
- allow natural language aliases like "detect voice" and "remove silence"
- cover voice activity detection in tests

## Testing
- `pytest tests/test_mcp_server.py::test_audio_operations -q` *(fails: ModuleNotFoundError: No module named 'webrtcvad')*


------
https://chatgpt.com/codex/tasks/task_e_68a7142c4764832c9a06a69057858e81