### PR TITLE
feat: add Monaco code canvas component

### DIFF
--- a/waveq-chat-ui/package.json
+++ b/waveq-chat-ui/package.json
@@ -19,7 +19,9 @@
     "next": "15.4.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "@monaco-editor/react": "^4.6.0",
+    "monaco-editor": "^0.45.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/waveq-chat-ui/src/components/code-canvas.tsx
+++ b/waveq-chat-ui/src/components/code-canvas.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Editor from '@monaco-editor/react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface CodeCanvasProps {
+  code: string
+  language: string
+  onChange: (value: string | undefined) => void
+  title?: string
+}
+
+export function CodeCanvas({ code, language, onChange, title }: CodeCanvasProps) {
+  return (
+    <Card className="w-full h-full">
+      {title && (
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+      )}
+      <CardContent className="p-0">
+        <Editor
+          height="400px"
+          defaultLanguage={language}
+          language={language}
+          value={code}
+          theme="vs-dark"
+          options={{ minimap: { enabled: false }, fontSize: 14 }}
+          onChange={onChange}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default CodeCanvas


### PR DESCRIPTION
## Summary
- add CodeCanvas component using Monaco editor inside ShadCN Card
- declare monaco dependencies in package.json

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a71eb91f00832c976655863b29e70c