### PR TITLE
Add sandboxed code execution endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,3 +121,26 @@ def test_chat_audio_llm_error(client, monkeypatch):
         files={"audio_file": ("test.wav", audio, "audio/wav")},
     )
     assert response.status_code == 502
+
+
+def test_run_code_success(client):
+    payload = {"language": "python", "code": "print('hi')"}
+    response = client.post("/api/run-code", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["output"].strip() == "hi"
+    assert body["errors"] == ""
+
+
+def test_run_code_error(client):
+    payload = {"language": "python", "code": "raise ValueError('bad')"}
+    response = client.post("/api/run-code", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert "ValueError" in body["errors"]
+
+
+def test_run_code_invalid_language(client):
+    payload = {"language": "javascript", "code": "console.log('hi')"}
+    response = client.post("/api/run-code", json=payload)
+    assert response.status_code == 400

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,6 +11,26 @@ from pathlib import Path
 # Provide a minimal stub for asyncio_mqtt to allow importing the server
 sys.modules.setdefault("asyncio_mqtt", types.ModuleType("asyncio_mqtt"))
 
+# Stub pkg_resources for webrtcvad if missing
+if "pkg_resources" not in sys.modules:
+    pkg_stub = types.ModuleType("pkg_resources")
+    pkg_stub.get_distribution = lambda name: types.SimpleNamespace(version="0.0")
+    sys.modules["pkg_resources"] = pkg_stub
+
+# Stub ffmpeg-python if not installed
+if "ffmpeg" not in sys.modules:
+    class _StubFFMPEG(types.ModuleType):
+        def input(self, file_path):
+            return file_path
+
+        def output(self, stream, out_path, format=None, **kwargs):
+            return out_path
+
+        def run(self, stream, overwrite_output=True):
+            Path(stream).touch()
+
+    sys.modules["ffmpeg"] = _StubFFMPEG("ffmpeg")
+
 # Provide a stub for audiomentations if it's not installed
 if "audiomentations" not in sys.modules:
     class _StubTransform:
@@ -38,7 +58,8 @@ if "audiomentations" not in sys.modules:
 # Ensure the project root is on the path when running tests directly
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
-
+import mcp_audio_server
+mcp_audio_server.ffmpeg = sys.modules["ffmpeg"]
 from mcp_audio_server import AudioProcessingMCP
 
 


### PR DESCRIPTION
## Summary
- add `/api/run-code` POST endpoint to execute Python snippets in a sandboxed subprocess
- validate incoming code requests and return structured output/error data
- test run-code endpoint and stub external dependencies for reliable testing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71ec5fa90832cba2df348a49717e4