### PR TITLE
feat: connect UI to API gateway with i18n support

### DIFF
--- a/waveq-chat-ui/src/app/api/audio/download/[requestId]/route.ts
+++ b/waveq-chat-ui/src/app/api/audio/download/[requestId]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function GET(req: NextRequest, { params }: { params: { requestId: string } }) {
+  const res = await fetch(`${API_BASE}/api/audio/download/${params.requestId}`)
+  const arrayBuffer = await res.arrayBuffer()
+  const headers: Record<string, string> = {}
+  const contentType = res.headers.get('content-type')
+  if (contentType) headers['Content-Type'] = contentType
+  const disposition = res.headers.get('content-disposition')
+  if (disposition) headers['Content-Disposition'] = disposition
+  return new NextResponse(arrayBuffer, { status: res.status, headers })
+}

--- a/waveq-chat-ui/src/app/api/audio/edit/route.ts
+++ b/waveq-chat-ui/src/app/api/audio/edit/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData()
+  const res = await fetch(`${API_BASE}/api/audio/edit`, {
+    method: 'POST',
+    body: formData
+  })
+
+  const contentType = res.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  }
+  const blob = await res.blob()
+  return new NextResponse(blob, { status: res.status })
+}

--- a/waveq-chat-ui/src/app/api/audio/requests/[requestId]/route.ts
+++ b/waveq-chat-ui/src/app/api/audio/requests/[requestId]/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function DELETE(req: NextRequest, { params }: { params: { requestId: string } }) {
+  const res = await fetch(`${API_BASE}/api/audio/requests/${params.requestId}`, { method: 'DELETE' })
+  const data = await res.json().catch(() => ({}))
+  return NextResponse.json(data, { status: res.status })
+}

--- a/waveq-chat-ui/src/app/api/audio/requests/route.ts
+++ b/waveq-chat-ui/src/app/api/audio/requests/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url)
+  const res = await fetch(`${API_BASE}/api/audio/requests${url.search}`)
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/waveq-chat-ui/src/app/api/audio/status/[requestId]/route.ts
+++ b/waveq-chat-ui/src/app/api/audio/status/[requestId]/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function GET(req: NextRequest, { params }: { params: { requestId: string } }) {
+  const res = await fetch(`${API_BASE}/api/audio/status/${params.requestId}`)
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/waveq-chat-ui/src/app/api/stats/route.ts
+++ b/waveq-chat-ui/src/app/api/stats/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+const API_BASE = process.env.API_GATEWAY_URL || 'http://localhost:8002'
+
+export async function GET() {
+  const res = await fetch(`${API_BASE}/api/stats`)
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/waveq-chat-ui/src/app/dashboard/page.tsx
+++ b/waveq-chat-ui/src/app/dashboard/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from '@/components/language-provider'
+
+interface Stats {
+  total_requests: number
+  pending_requests: number
+  completed_requests: number
+  success_rate: number
+}
+
+export default function Dashboard() {
+  const [stats, setStats] = useState<Stats | null>(null)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    fetch('/api/stats')
+      .then(res => res.json())
+      .then(setStats)
+      .catch(() => {})
+  }, [])
+
+  if (!stats) {
+    return <p className="p-4">{t('loading')}</p>
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold mb-4">{t('dashboardTitle')}</h1>
+      <ul className="space-y-1">
+        <li>{t('totalRequests')}: {stats.total_requests}</li>
+        <li>{t('pendingRequests')}: {stats.pending_requests}</li>
+        <li>{t('completedRequests')}: {stats.completed_requests}</li>
+        <li>{t('successRate')}: {stats.success_rate}%</li>
+      </ul>
+    </div>
+  )
+}

--- a/waveq-chat-ui/src/app/layout.tsx
+++ b/waveq-chat-ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { LanguageProvider } from "@/components/language-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <LanguageProvider>{children}</LanguageProvider>
       </body>
     </html>
   );

--- a/waveq-chat-ui/src/app/page.tsx
+++ b/waveq-chat-ui/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ChatInterface } from '@/components/chat-interface'
 import { Button } from '@/components/ui/button'
 import { Settings, Sun, Moon, Key, Bot, Download, FileText, Calendar, Clock, FileAudio, Trash2, Upload } from 'lucide-react'
 import { UploadsSection } from '@/components/uploads-section'
+import { useTranslation } from '@/components/language-provider'
 
 // Types for exported files
 interface ExportedFile {
@@ -238,6 +239,7 @@ function ExportsSection({ theme }: { theme: 'dark' | 'light' }) {
 }
 
 export default function Home() {
+  const { lang, setLang } = useTranslation()
   const [theme, setTheme] = useState<'dark' | 'light'>('dark')
   const [currentPage, setCurrentPage] = useState<'chat' | 'settings' | 'exports' | 'uploads'>('chat')
   const [apiKey, setApiKey] = useState('')
@@ -680,8 +682,8 @@ export default function Home() {
                 variant="outline"
                 onClick={() => handleThemeChange(theme === 'dark' ? 'light' : 'dark')}
                 className={`w-full justify-start gap-3 h-12 text-left border-2 hover:border-purple-500 transition-all duration-200 ${
-                  theme === 'dark' 
-                    ? 'bg-gray-800 border-gray-600 hover:bg-gray-700' 
+                  theme === 'dark'
+                    ? 'bg-gray-800 border-gray-600 hover:bg-gray-700'
                     : 'bg-white border-gray-200 hover:bg-gray-50'
                 }`}
               >
@@ -706,6 +708,33 @@ export default function Home() {
                     </div>
                   </>
                 )}
+              </Button>
+            </div>
+
+            {/* Language Toggle */}
+            <div className="space-y-3">
+              <Button
+                variant="outline"
+                onClick={() => setLang(lang === 'he' ? 'en' : 'he')}
+                className={`w-full justify-start gap-3 h-12 text-left border-2 hover:border-teal-500 transition-all duration-200 ${
+                  theme === 'dark'
+                    ? 'bg-gray-800 border-gray-600 hover:bg-gray-700'
+                    : 'bg-white border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                <div className="w-8 h-8 bg-teal-500/20 rounded-lg flex items-center justify-center">
+                  <span className="font-semibold">
+                    {lang === 'he' ? 'EN' : 'HE'}
+                  </span>
+                </div>
+                <div className="text-left">
+                  <div className="font-medium">
+                    {lang === 'he' ? 'English' : 'עברית'}
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {lang === 'he' ? 'Change language' : 'החלפת שפה'}
+                  </div>
+                </div>
               </Button>
             </div>
 

--- a/waveq-chat-ui/src/components/language-provider.tsx
+++ b/waveq-chat-ui/src/components/language-provider.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+import { translations, Lang } from '@/i18n/i18n'
+
+interface LanguageContextValue {
+  lang: Lang
+  setLang: (lang: Lang) => void
+  t: (key: keyof typeof translations['he'], params?: Record<string, any>) => string
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined)
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>('he')
+
+  const t = (key: keyof typeof translations['he'], params?: Record<string, any>) => {
+    let text = translations[lang][key] as string
+    if (params) {
+      Object.keys(params).forEach(p => {
+        text = text.replace(`{${p}}`, params[p])
+      })
+    }
+    return text
+  }
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export function useTranslation() {
+  const ctx = useContext(LanguageContext)
+  if (!ctx) throw new Error('useTranslation must be used within LanguageProvider')
+  return ctx
+}

--- a/waveq-chat-ui/src/components/uploads-section.tsx
+++ b/waveq-chat-ui/src/components/uploads-section.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/components/language-provider'
 import { 
   FileAudio, 
   FileText, 
@@ -36,6 +37,7 @@ interface UploadsSectionProps {
 }
 
 export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
+  const { t, lang } = useTranslation()
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([])
   const [filterStatus, setFilterStatus] = useState<'all' | 'uploaded' | 'processed' | 'error'>('all')
   const [sortBy, setSortBy] = useState<'date' | 'name' | 'size' | 'type'>('date')
@@ -81,7 +83,8 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
   }
 
   const formatDate = (date: Date) => {
-    return date.toLocaleDateString('he-IL', {
+    const locale = lang === 'he' ? 'he-IL' : 'en-US'
+    return date.toLocaleDateString(locale, {
       year: 'numeric',
       month: 'short',
       day: 'numeric'
@@ -89,7 +92,8 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
   }
 
   const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('he-IL', {
+    const locale = lang === 'he' ? 'he-IL' : 'en-US'
+    return date.toLocaleTimeString(locale, {
       hour: '2-digit',
       minute: '2-digit'
     })
@@ -104,13 +108,13 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'uploaded':
-        return <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full">הועלה</span>
+        return <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full">{t('statusUploaded')}</span>
       case 'processed':
-        return <span className="px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">עובד</span>
+        return <span className="px-2 py-1 text-xs font-medium bg-green-100 text-green-800 rounded-full">{t('statusProcessed')}</span>
       case 'error':
-        return <span className="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded-full">שגיאה</span>
+        return <span className="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded-full">{t('statusError')}</span>
       default:
-        return <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full">לא ידוע</span>
+        return <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-full">{t('statusUnknown')}</span>
     }
   }
 
@@ -155,10 +159,10 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
         <CardContent className="p-8 text-center">
           <UploadIcon className={`w-16 h-16 mx-auto mb-4 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-300'}`} />
           <h3 className={`text-lg font-medium mb-2 ${theme === 'dark' ? 'text-gray-200' : 'text-gray-800'}`}>
-            אין קבצים שהועלו עדיין
+            {t('noUploadedFiles')}
           </h3>
           <p className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
-            העלה קובץ אודיו כדי לראות אותו כאן
+            {t('uploadPrompt')}
           </p>
         </CardContent>
       </Card>
@@ -171,10 +175,10 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
       <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
         <div>
           <h2 className={`text-2xl font-bold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
-            קבצים שהועלו
+            {t('uploadedFiles')}
           </h2>
           <p className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
-            {uploadedFiles.length} קובץ הועלה בסך הכל
+            {t('totalFiles', { count: uploadedFiles.length })}
           </p>
         </div>
         
@@ -189,10 +193,10 @@ export function UploadsSection({ theme = 'light' }: UploadsSectionProps) {
                 : 'bg-white border-gray-300 text-gray-900'
             }`}
           >
-            <option value="all">כל הקבצים</option>
-            <option value="uploaded">הועלו</option>
-            <option value="processed">עובדו</option>
-            <option value="error">שגיאות</option>
+            <option value="all">{t('filterAll')}</option>
+            <option value="uploaded">{t('filterUploaded')}</option>
+            <option value="processed">{t('filterProcessed')}</option>
+            <option value="error">{t('filterError')}</option>
           </select>
           
           {/* Sort By */}

--- a/waveq-chat-ui/src/i18n/i18n.ts
+++ b/waveq-chat-ui/src/i18n/i18n.ts
@@ -1,0 +1,44 @@
+export const translations = {
+  he: {
+    uploadedFiles: 'קבצים שהועלו',
+    noUploadedFiles: 'אין קבצים שהועלו עדיין',
+    uploadPrompt: 'העלה קובץ אודיו כדי לראות אותו כאן',
+    totalFiles: '{count} קובץ הועלה בסך הכל',
+    filterAll: 'כל הקבצים',
+    filterUploaded: 'הועלו',
+    filterProcessed: 'עובדו',
+    filterError: 'שגיאות',
+    statusUploaded: 'הועלה',
+    statusProcessed: 'עובד',
+    statusError: 'שגיאה',
+    statusUnknown: 'לא ידוע',
+    dashboardTitle: 'לוח בקרה',
+    totalRequests: 'סה"כ בקשות',
+    pendingRequests: 'בקשות ממתינות',
+    completedRequests: 'בקשות שהושלמו',
+    successRate: 'אחוז הצלחה',
+    loading: 'טוען...'
+  },
+  en: {
+    uploadedFiles: 'Uploaded Files',
+    noUploadedFiles: 'No files uploaded yet',
+    uploadPrompt: 'Upload an audio file to see it here',
+    totalFiles: '{count} files uploaded',
+    filterAll: 'All files',
+    filterUploaded: 'Uploaded',
+    filterProcessed: 'Processed',
+    filterError: 'Errors',
+    statusUploaded: 'Uploaded',
+    statusProcessed: 'Processed',
+    statusError: 'Error',
+    statusUnknown: 'Unknown',
+    dashboardTitle: 'Dashboard',
+    totalRequests: 'Total Requests',
+    pendingRequests: 'Pending Requests',
+    completedRequests: 'Completed Requests',
+    successRate: 'Success Rate',
+    loading: 'Loading...'
+  }
+} as const;
+
+export type Lang = keyof typeof translations;


### PR DESCRIPTION
## Summary
- add Next.js API routes proxying audio and stats requests to FastAPI gateway
- implement simple translation provider and language toggle
- fetch and display backend stats on new dashboard page

## Testing
- `npm run lint` *(fails: Unexpected any and unescaped entities)*
- `pytest` *(fails: KeyError: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68a789addbd0832c8458db918f0f0bf4