### PR TITLE
Add dashboard Dockerfile and usage docs

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,34 @@
+FROM python:3.11-slim
+
+# Install system dependencies for audio processing
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    libsndfile1 \
+    libasound2-dev \
+    portaudio19-dev \
+    python3-dev \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Create non-root user
+RUN useradd -m -u 1000 waveq && chown -R waveq:waveq /app
+USER waveq
+
+# Expose port
+EXPOSE 8001
+
+# Default command
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ docker-compose up -d
 # או השתמש בסקריפט הפעלה
 .\start_system.ps1
 ```
+### בניית והפעלת Web Dashboard עם Docker:
+
+```bash
+# בניית התמונה
+docker build -f Dockerfile.dashboard -t waveq-dashboard .
+
+# הפעלת הקונטיינר
+docker run -p 8001:8001 waveq-dashboard
+```
 
 ### התקנה ידנית:
 


### PR DESCRIPTION
## Summary
- add Dockerfile for the web dashboard based on Python 3.11 and install project dependencies
- document how to build and run the dashboard container in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a793f02674832ca7732f82a664bda3