### PR TITLE
Add structured logging and MQTT log tests

### DIFF
--- a/tests/test_mqtt_logging.py
+++ b/tests/test_mqtt_logging.py
@@ -1,0 +1,47 @@
+import asyncio
+import logging
+import types
+from unittest.mock import AsyncMock
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+import api_gateway
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def subscribe(self, topic):
+        pass
+
+
+def test_mqtt_connect_disconnect_logs(monkeypatch, caplog):
+    monkeypatch.setattr(
+        api_gateway,
+        "aiomqtt",
+        types.SimpleNamespace(Client=DummyClient),
+        raising=False,
+    )
+    monkeypatch.setattr(api_gateway.MCPClient, "listen_status_updates", AsyncMock())
+    client = api_gateway.MCPClient()
+
+    async def run():
+        with caplog.at_level(logging.INFO):
+            await client.connect()
+            await client.disconnect()
+
+    asyncio.run(run())
+
+    messages = caplog.messages
+    assert any("Connected to MQTT broker" in m for m in messages)
+    assert any("Disconnected from MQTT broker" in m for m in messages)


### PR DESCRIPTION
## Summary
- add logging configuration and logger to api_gateway
- replace print statements with logger calls and log MQTT disconnect
- test that MQTT connect/disconnect write to logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a793f465d8832ca6e8a0223dcddab4