### PR TITLE
Clean up temporary audio files and add scheduled maintenance

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+
+def cleanup_file(path: str | Path) -> None:
+    """Delete a file if it exists."""
+    if not path:
+        return
+    try:
+        Path(path).unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def cleanup_old_files(directory: str | Path, max_age_seconds: int) -> None:
+    """Remove files older than max_age_seconds from a directory."""
+    dir_path = Path(directory)
+    if not dir_path.exists():
+        return
+    cutoff = time.time() - max_age_seconds
+    for file in dir_path.glob("*"):
+        try:
+            if file.is_file() and file.stat().st_mtime < cutoff:
+                file.unlink()
+        except Exception:
+            continue

--- a/mcp_audio_server.py
+++ b/mcp_audio_server.py
@@ -25,6 +25,7 @@ import torchaudio
 
 # Import our Audio Agent
 from audio_agent_library import AudioAgent
+from file_utils import cleanup_file
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -374,6 +375,10 @@ class AudioProcessingMCP:
                 continue
 
             result = await method(audio_path, params)
+
+            cleanup_file(audio_path)
+            for extra in params.get("additional_files", []):
+                cleanup_file(extra)
 
             await client.publish(
                 f"audio/results/{req_id}",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ def client(tmp_path, monkeypatch):
     # Redirect file storage to temporary directory
     monkeypatch.setattr(api_gateway, "UPLOAD_DIR", tmp_path)
     monkeypatch.setattr(api_gateway, "PROCESSED_DIR", tmp_path)
+    api_gateway.active_requests.clear()
     # Mock MQTT interactions
     monkeypatch.setattr(api_gateway.mcp_client, "connect", AsyncMock())
     monkeypatch.setattr(api_gateway.mcp_client, "publish_request", AsyncMock(return_value=True))
@@ -129,4 +130,34 @@ def test_supported_operations_include_time_stretch(client):
     assert response.status_code == 200
     ops = response.json()["operations"]
     assert "time_stretch_torch" in ops
+
+
+def test_cleanup_file_removes_path(tmp_path):
+    temp = tmp_path / "temp.txt"
+    temp.write_text("hi")
+    api_gateway.cleanup_file(temp)
+    assert not temp.exists()
+
+
+def test_download_removes_files(client, tmp_path):
+    audio = io.BytesIO(b"test audio")
+    resp = client.post(
+        "/api/audio/edit",
+        data={"operation": "trim", "parameters": "{}"},
+        files={"audio_file": ("test.wav", audio, "audio/wav")},
+    )
+    request_id = resp.json()["request_id"]
+    original = tmp_path / f"{request_id}_test.wav"
+    assert original.exists()
+
+    original_stem = original.stem
+    api_gateway.handle_status_update(request_id, "completed", {})
+    assert not original.exists()
+
+    processed = tmp_path / f"{original_stem}_out.wav"
+    processed.write_bytes(b"processed")
+
+    response = client.get(f"/api/audio/download/{request_id}")
+    assert response.status_code == 200
+    assert not processed.exists()
 


### PR DESCRIPTION
## Summary
- add reusable `cleanup_file` helper and old-file pruning utilities
- remove uploaded audio after processing and purge results after download
- schedule periodic cleanup of stale files on the API gateway
- ensure MCP server deletes consumed input files
- test file deletion behavior to avoid accumulation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79404dc20832c84d36076b04e32d1