### PR TITLE
feat: support audio file uploads

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -189,7 +189,7 @@
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-2">קובץ אודיו</label>
-                            <input type="text" x-model="newRequest.audio_file" required
+                            <input type="file" x-ref="audio_file" name="audio_file" required
                                    class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent">
                         </div>
                         <div>
@@ -247,7 +247,6 @@
                 },
                 newRequest: {
                     client_name: '',
-                    audio_file: '',
                     edit_type: '',
                     description: '',
                     priority: 'normal'
@@ -285,7 +284,7 @@
                     try {
                         const formData = new FormData();
                         formData.append('client_name', this.newRequest.client_name);
-                        formData.append('audio_file', this.newRequest.audio_file);
+                        formData.append('audio_file', this.$refs.audio_file.files[0]);
                         formData.append('edit_type', this.newRequest.edit_type);
                         formData.append('description', this.newRequest.description);
                         formData.append('priority', this.newRequest.priority);
@@ -299,7 +298,8 @@
                             const result = await response.json();
                             alert(`בקשה נשלחה בהצלחה! מזהה: ${result.request_id}`);
                             this.showNewRequestModal = false;
-                            this.newRequest = { client_name: '', audio_file: '', edit_type: '', description: '', priority: 'normal' };
+                            this.newRequest = { client_name: '', edit_type: '', description: '', priority: 'normal' };
+                            this.$refs.audio_file.value = '';
                             await this.refreshData();
                         }
                     } catch (error) {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -215,7 +215,7 @@
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-2">קובץ אודיו</label>
-                            <input type="text" x-model="newRequest.audio_file" required
+                            <input type="file" x-ref="audio_file" name="audio_file" required
                                    class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent">
                         </div>
                         <div>
@@ -275,7 +275,6 @@
                 recentActivity: [],
                 newRequest: {
                     client_name: '',
-                    audio_file: '',
                     edit_type: '',
                     description: '',
                     priority: 'normal'
@@ -403,7 +402,7 @@
                     try {
                         const formData = new FormData();
                         formData.append('client_name', this.newRequest.client_name);
-                        formData.append('audio_file', this.newRequest.audio_file);
+                        formData.append('audio_file', this.$refs.audio_file.files[0]);
                         formData.append('edit_type', this.newRequest.edit_type);
                         formData.append('description', this.newRequest.description);
                         formData.append('priority', this.newRequest.priority);
@@ -417,7 +416,8 @@
                             const result = await response.json();
                             alert(`בקשה נשלחה בהצלחה! מזהה: ${result.request_id}`);
                             this.showNewRequestModal = false;
-                            this.newRequest = { client_name: '', audio_file: '', edit_type: '', description: '', priority: 'normal' };
+                            this.newRequest = { client_name: '', edit_type: '', description: '', priority: 'normal' };
+                            this.$refs.audio_file.value = '';
                             await this.refreshData();
                         }
                     } catch (error) {

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -207,7 +207,7 @@
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-2">קובץ אודיו</label>
-                            <input type="text" x-model="newRequest.audio_file" required
+                            <input type="file" x-ref="audio_file" name="audio_file" required
                                    class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent">
                         </div>
                         <div>
@@ -265,7 +265,6 @@
                 pageSize: 10,
                 newRequest: {
                     client_name: '',
-                    audio_file: '',
                     edit_type: '',
                     description: '',
                     priority: 'normal'
@@ -351,7 +350,7 @@
                     try {
                         const formData = new FormData();
                         formData.append('client_name', this.newRequest.client_name);
-                        formData.append('audio_file', this.newRequest.audio_file);
+                        formData.append('audio_file', this.$refs.audio_file.files[0]);
                         formData.append('edit_type', this.newRequest.edit_type);
                         formData.append('description', this.newRequest.description);
                         formData.append('priority', this.newRequest.priority);
@@ -365,7 +364,8 @@
                             const result = await response.json();
                             alert(`בקשה נשלחה בהצלחה! מזהה: ${result.request_id}`);
                             this.showNewRequestModal = false;
-                            this.newRequest = { client_name: '', audio_file: '', edit_type: '', description: '', priority: 'normal' };
+                            this.newRequest = { client_name: '', edit_type: '', description: '', priority: 'normal' };
+                            this.$refs.audio_file.value = '';
                             await this.refreshData();
                         }
                     } catch (error) {


### PR DESCRIPTION
## Summary
- switch audio_file fields to file inputs across templates
- send audio_file via FormData in submit handlers
- accept UploadFile on /api/audio-edit and save to uploads directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a5433e5c832cb8187ca8db669a9e