### PR TITLE
Require authentication for analytics and chat pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -244,13 +244,13 @@ async def settings_page(request: Request, user: User = Depends(get_current_user)
     return templates.TemplateResponse("settings.html", {"request": request, "user": user})
 
 @app.get("/analytics", response_class=HTMLResponse)
-async def analytics_page(request: Request):
-    return templates.TemplateResponse("analytics.html", {"request": request})
+async def analytics_page(request: Request, user: User = Depends(get_current_user)):
+    return templates.TemplateResponse("analytics.html", {"request": request, "user": user})
 
 # Chat routes
 @app.get("/chat", response_class=HTMLResponse)
-async def chat_page(request: Request):
-    return templates.TemplateResponse("chat.html", {"request": request})
+async def chat_page(request: Request, user: User = Depends(get_current_user)):
+    return templates.TemplateResponse("chat.html", {"request": request, "user": user})
 
 @app.post("/chat")
 async def handle_chat(file: UploadFile = File(...), message: str = Form(...)):

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -10,6 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gray-50 font-sans">
+    {% if user %}
     <div x-data="analyticsManager()" class="min-h-screen">
         <!-- Sidebar -->
         <div class="fixed inset-y-0 right-0 z-50 w-64 bg-gradient-to-b from-purple-600 to-purple-800 shadow-lg">
@@ -231,6 +232,12 @@
             </main>
         </div>
     </div>
+    {% else %}
+    <div class="min-h-screen flex flex-col items-center justify-center">
+        <p class="text-red-600 mb-4">אין לך הרשאה לצפות בדף זה.</p>
+        <a href="/login" class="text-purple-600 underline">לעמוד ההתחברות</a>
+    </div>
+    {% endif %}
 
     <script>
         function analyticsManager() {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-50 flex items-center justify-center min-h-screen">
+    {% if user %}
     <form action="/chat" method="post" enctype="multipart/form-data" class="bg-white p-6 rounded-lg shadow-md space-y-4">
         <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">קובץ אודיו</label>
@@ -18,5 +19,11 @@
         </div>
         <button type="submit" class="w-full bg-purple-600 text-white py-2 rounded hover:bg-purple-700">שלח</button>
     </form>
+    {% else %}
+    <div class="text-center">
+        <p class="text-red-600 mb-4">אין לך הרשאה לצפות בדף זה.</p>
+        <a href="/login" class="text-purple-600 underline">לעמוד ההתחברות</a>
+    </div>
+    {% endif %}
 </body>
 </html>

--- a/tests/test_auth_pages.py
+++ b/tests/test_auth_pages.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+from fastapi.testclient import TestClient
+
+# Provide a minimal stub for the jose library if it's missing
+jose_stub = types.ModuleType("jose")
+
+class JWTError(Exception):
+    pass
+
+jose_stub.JWTError = JWTError
+jose_stub.jwt = types.SimpleNamespace(
+    encode=lambda *args, **kwargs: "token",
+    decode=lambda *args, **kwargs: {}
+)
+sys.modules.setdefault("jose", jose_stub)
+
+# Provide a minimal stub for passlib CryptContext if passlib is missing
+passlib_stub = types.ModuleType("passlib")
+passlib_context_stub = types.ModuleType("passlib.context")
+
+class CryptContext:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def hash(self, password):
+        return password
+
+    def verify(self, plain_password, hashed_password):
+        return plain_password == hashed_password
+
+passlib_context_stub.CryptContext = CryptContext
+sys.modules.setdefault("passlib", passlib_stub)
+sys.modules.setdefault("passlib.context", passlib_context_stub)
+
+# Ensure project root is on sys.path for module imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Create required directories for app initialization
+os.makedirs("static", exist_ok=True)
+
+import main
+
+client = TestClient(main.app)
+
+def test_analytics_requires_auth():
+    response = client.get("/analytics")
+    assert response.status_code == 401
+
+
+def test_chat_requires_auth():
+    response = client.get("/chat")
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Enforce authentication on analytics and chat pages
- Display login prompt in analytics and chat templates when unauthenticated
- Add tests confirming restricted access without token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*
- `pip install python-jose[cryptography] -q` *(fails: Could not find a version that satisfies the requirement)*
- `pytest tests/test_auth_pages.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7a54b94c0832ca8b20853c0b689bc