### PR TITLE
Add live request status updates via WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,34 @@ DELETE /api/audio/requests/{request_id}
 GET /api/audio/operations
 ```
 
+## 🔔 עדכוני סטטוס בזמן אמת
+
+המערכת מספקת עדכוני סטטוס בזמן אמת באמצעות WebSocket.
+
+### נקודת קצה
+`ws://<server-host>/ws/requests`
+
+### פורמט הודעה (JSON)
+
+```json
+{
+  "request_id": "REQ-000001",
+  "status": "processing",
+  "client_name": "client1",
+  "audio_file": "file.wav",
+  "edit_type": "noise_reduction",
+  "description": "Remove noise",
+  "priority": "normal",
+  "created_at": "2024-01-01T12:00:00",
+  "updated_at": "2024-01-01T12:00:00",
+  "processing_time": null,
+  "result_file": null,
+  "error_message": null
+}
+```
+
+הדשבורד מתחבר לנקודת קצה זו ומקבל עדכונים על בקשות חדשות ושינויים בסטטוס ללא צורך ברענון ידני של העמוד.
+
 ## 🔧 הגדרות וקונפיגורציה
 
 ### משתני סביבה:

--- a/main.py
+++ b/main.py
@@ -1,4 +1,17 @@
-from fastapi import FastAPI, Request, Form, HTTPException, BackgroundTasks, UploadFile, File, Depends, Response, Cookie
+from fastapi import (
+    FastAPI,
+    Request,
+    Form,
+    HTTPException,
+    BackgroundTasks,
+    UploadFile,
+    File,
+    Depends,
+    Response,
+    Cookie,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, RedirectResponse
@@ -93,6 +106,53 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # Templates
 templates = Jinja2Templates(directory="templates")
+
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: dict):
+        for connection in self.active_connections:
+            await connection.send_json(message)
+
+
+ws_manager = ConnectionManager()
+
+
+@app.websocket("/ws/requests")
+async def websocket_requests(websocket: WebSocket):
+    await ws_manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        ws_manager.disconnect(websocket)
+
+
+def request_to_dict(req: AudioEditRequest) -> dict:
+    return {
+        "request_id": req.request_id,
+        "client_name": req.client_name,
+        "audio_file": req.audio_file,
+        "edit_type": req.edit_type,
+        "description": req.description,
+        "priority": req.priority,
+        "status": req.status,
+        "created_at": req.created_at.isoformat(),
+        "updated_at": req.updated_at.isoformat(),
+        "processing_time": req.processing_time,
+        "result_file": req.result_file,
+        "error_message": req.error_message,
+    }
 
 # Authentication setup
 SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "change_me")
@@ -295,6 +355,8 @@ async def submit_audio_edit_request(
         db.commit()
         db.refresh(new_request)
 
+        await ws_manager.broadcast(request_to_dict(new_request))
+
         # Security: Log the request
         logger.info(f"Audio edit request submitted: {new_request.request_id} by {request_data.client_name}")
 
@@ -392,6 +454,8 @@ async def update_request_status(
             req.processing_time = (req.updated_at - req.created_at).total_seconds()
         db.commit()
 
+        await ws_manager.broadcast(request_to_dict(req))
+
         return {"success": True, "message": f"Request {request_id} status updated to {status}"}
 
     raise HTTPException(status_code=404, detail="Request not found")
@@ -485,6 +549,7 @@ async def process_audio_request(request_id: str):
             req.processing_time = (req.updated_at - req.created_at).total_seconds()
             req.result_file = f"processed_{req.audio_file}"
             db.commit()
+            await ws_manager.broadcast(request_to_dict(req))
     finally:
         db.close()
 
@@ -496,6 +561,8 @@ async def process_request(request_id: str, background_tasks: BackgroundTasks, db
         req.status = "processing"
         req.updated_at = datetime.now()
         db.commit()
+
+        await ws_manager.broadcast(request_to_dict(req))
 
         # Add background task to simulate processing
         background_tasks.add_task(process_audio_request, request_id)

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -263,6 +263,7 @@
                 editTypeFilter: '',
                 currentPage: 1,
                 pageSize: 10,
+                socket: null,
                 newRequest: {
                     client_name: '',
                     audio_file: '',
@@ -278,6 +279,18 @@
                 
                 async init() {
                     await this.refreshData();
+                    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+                    this.socket = new WebSocket(`${protocol}://${window.location.host}/ws/requests`);
+                    this.socket.onmessage = (event) => {
+                        const data = JSON.parse(event.data);
+                        const index = this.requests.findIndex(r => r.request_id === data.request_id);
+                        if (index !== -1) {
+                            this.requests[index] = data;
+                        } else {
+                            this.requests.push(data);
+                        }
+                        this.applyFilters();
+                    };
                     // Auto-refresh every 30 seconds
                     setInterval(() => this.refreshData(), 30000);
                 },


### PR DESCRIPTION
## Summary
- broadcast request status updates over `/ws/requests` WebSocket
- listen for WebSocket messages in dashboard to refresh request list live
- document WebSocket usage and JSON message format in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a54f4a64832cb924857ba08ec877