### PR TITLE
Limit audio operations to v1 set and validate

### DIFF
--- a/audio_agent_api.py
+++ b/audio_agent_api.py
@@ -17,8 +17,8 @@ import uuid
 from datetime import datetime
 import logging
 
-# Import our Audio Agent
-from audio_agent_library import AudioAgent
+# Import our Audio Agent and exposed operations
+from audio_agent_library import AudioAgent, V1_OPERATIONS
 from gemini_audio_integration import GeminiAudioIntegration
 
 # Configure logging
@@ -134,7 +134,13 @@ async def process_natural_language_audio(
             gemini_insights=result.get("gemini_insights"),
             timestamp=result["timestamp"]
         )
-        
+
+    except ValueError as e:
+        logger.warning(f"Unsupported operations requested: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
     except Exception as e:
         logger.error(f"Error processing natural language request: {e}")
         raise HTTPException(
@@ -200,7 +206,13 @@ async def process_audio_upload(
             gemini_insights=result.get("gemini_insights"),
             timestamp=result["timestamp"]
         )
-        
+
+    except ValueError as e:
+        logger.warning(f"Unsupported operations requested: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
     except Exception as e:
         logger.error(f"Error processing audio upload: {e}")
         raise HTTPException(
@@ -213,8 +225,8 @@ async def get_supported_operations():
     """Get list of supported audio operations with examples"""
     try:
         return {
-            "operations": audio_agent.supported_operations,
-            "total_operations": len(audio_agent.supported_operations),
+            "operations": V1_OPERATIONS,
+            "total_operations": len(V1_OPERATIONS),
             "agent_version": "1.0.0",
             "timestamp": datetime.now().isoformat()
         }
@@ -229,8 +241,17 @@ async def get_supported_operations():
 async def get_help_text():
     """Get help text for supported operations"""
     try:
+        help_text = "🎵 WaveQ Audio Agent - Supported Operations:\n\n"
+        for operation, info in V1_OPERATIONS.items():
+            help_text += f"🔧 {operation.upper()}\n"
+            help_text += f"   Description: {info['description']}\n"
+            help_text += f"   Aliases: {', '.join(info['aliases'])}\n"
+            help_text += f"   Examples:\n"
+            for example in info['examples']:
+                help_text += f"     • {example}\n"
+            help_text += "\n"
         return {
-            "help_text": audio_agent.get_help_text(),
+            "help_text": help_text,
             "timestamp": datetime.now().isoformat()
         }
     except Exception as e:

--- a/audio_agent_library.py
+++ b/audio_agent_library.py
@@ -447,7 +447,7 @@ class AudioAgent:
             request["operations"].append(system_op)
         
         return request
-    
+
     def get_help_text(self) -> str:
         """Get help text for supported operations"""
         help_text = "🎵 WaveQ Audio Agent - Supported Operations:\n\n"
@@ -462,6 +462,18 @@ class AudioAgent:
             help_text += "\n"
         
         return help_text
+
+# Expose limited set of operations for API v1
+V1_OPERATIONS = {
+    op: AudioAgent().supported_operations[op]
+    for op in [
+        "trim",
+        "normalize",
+        "noise_reduction",
+        "equalize",
+        "merge",
+    ]
+}
 
 # Example usage
 if __name__ == "__main__":

--- a/flow.yaml
+++ b/flow.yaml
@@ -1,0 +1,40 @@
+operations:
+  noise_reduction:
+    priority: 1
+    parameters:
+      strength:
+        type: float
+        description: Amount of noise reduction to apply
+  normalize:
+    priority: 2
+    parameters:
+      target_db:
+        type: float
+        description: Target decibel level
+  equalize:
+    priority: 3
+    parameters:
+      low_gain:
+        type: float
+        description: Low frequency gain adjustment
+      mid_gain:
+        type: float
+        description: Mid frequency gain adjustment
+      high_gain:
+        type: float
+        description: High frequency gain adjustment
+  trim:
+    priority: 4
+    parameters:
+      start_time:
+        type: float
+        description: Start time in seconds
+      end_time:
+        type: float
+        description: End time in seconds
+  merge:
+    priority: 5
+    parameters:
+      additional_files:
+        type: list[str]
+        description: List of audio file paths to merge

--- a/gemini_audio_integration.py
+++ b/gemini_audio_integration.py
@@ -12,8 +12,8 @@ from typing import Dict, List, Any, Optional
 from datetime import datetime
 import asyncio
 
-# Import our Audio Agent
-from audio_agent_library import AudioAgent
+# Import our Audio Agent and exposed operations
+from audio_agent_library import AudioAgent, V1_OPERATIONS
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -79,7 +79,17 @@ Always be helpful, clear, and professional. If you're unsure about something, as
         operation_chain = self.audio_agent.generate_operation_chain(
             parsed_operations["operations"]
         )
-        
+
+        # Validate operations against API v1 allowed set
+        unsupported = [
+            op["operation"] for op in operation_chain
+            if op["operation"] not in V1_OPERATIONS
+        ]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported operations requested: {', '.join(unsupported)}"
+            )
+
         # Step 3: Create processing request
         processing_request = self.audio_agent.create_processing_request(
             operation_chain, audio_file


### PR DESCRIPTION
## Summary
- expose only `trim`, `normalize`, `noise_reduction`, `equalize` and `merge` in new `V1_OPERATIONS`
- validate parsed operations against allowed set and reject unsupported ones
- document v1 operations and their parameters in `flow.yaml`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'email_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68a7bb9eab80832cae2673551bec6725